### PR TITLE
Remove rxjs-pipe-ext

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,13 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@rxjsx/rxjsx": "^0.1.0",
         "body-parser": "^1.19.0",
         "express": "^4.17.1",
         "inversify": "^5.0.5",
         "inversify-binding-decorators": "^4.0.0",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.1.0",
-        "rxjs-pipe-ext": "^3.0.0",
         "tsoa": "^3.5.2"
       },
       "devDependencies": {
@@ -1278,6 +1278,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@rxjsx/rxjsx": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@rxjsx/rxjsx/-/rxjsx-0.1.0.tgz",
+      "integrity": "sha512-vsBJ/nvDCfT7RUo6lVbjq5z01UcFWLWe478+EE35QuhrqP9n3RMH71Qj2SmawI2qY1Dbikd+m9f+tF6ZzK/Ing=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -2682,8 +2687,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -3544,7 +3548,6 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {
@@ -4670,7 +4673,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^27.0.6",
         "jest-serializer": "^27.0.6",
@@ -5979,9 +5981,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -6850,11 +6849,6 @@
       "dependencies": {
         "tslib": "~2.1.0"
       }
-    },
-    "node_modules/rxjs-pipe-ext": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rxjs-pipe-ext/-/rxjs-pipe-ext-3.0.0.tgz",
-      "integrity": "sha512-l8gjlZ7bmDcVoXrx6kAW3j5dy6FQJ173ymEnxZnf8+ZqcMZzWDlQenw2FaL5iKebozOVQOUs2kZn5CMTWv3Sfg=="
     },
     "node_modules/rxjs/node_modules/tslib": {
       "version": "2.1.0",
@@ -8840,6 +8834,11 @@
         "@nodelib/fs.scandir": "2.1.4",
         "fastq": "^1.6.0"
       }
+    },
+    "@rxjsx/rxjsx": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@rxjsx/rxjsx/-/rxjsx-0.1.0.tgz",
+      "integrity": "sha512-vsBJ/nvDCfT7RUo6lVbjq5z01UcFWLWe478+EE35QuhrqP9n3RMH71Qj2SmawI2qY1Dbikd+m9f+tF6ZzK/Ing=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
@@ -13132,11 +13131,6 @@
           "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
         }
       }
-    },
-    "rxjs-pipe-ext": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rxjs-pipe-ext/-/rxjs-pipe-ext-3.0.0.tgz",
-      "integrity": "sha512-l8gjlZ7bmDcVoXrx6kAW3j5dy6FQJ173ymEnxZnf8+ZqcMZzWDlQenw2FaL5iKebozOVQOUs2kZn5CMTWv3Sfg=="
     },
     "safe-buffer": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "npm": ">=6.0.0"
   },
   "dependencies": {
+    "@rxjsx/rxjsx": "^0.1.0",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "inversify": "^5.0.5",


### PR DESCRIPTION
This PR removes the deprecated package `rxjs-pipe-ext` and adds `@rxjsx/rxjsx` instead.
I didn't had to change anything else. Seems like `rxjs-pipe-ext` wasn't used anymore.

I still added `@rxjsx/rxjsx` to prevent someone else would try to use `rxjs-pipe-ext` again :) 

Fixes #3  